### PR TITLE
Allow stackimport to compile successfully on GNU/Linux-based systems.

### DIFF
--- a/CBuf.cpp
+++ b/CBuf.cpp
@@ -7,6 +7,9 @@
  *
  */
 
+#if !MAC_CODE
+#include <cstring>
+#endif
 #include "CBuf.h"
 #include "byteutils.h"
 #include "assert.h"

--- a/CStackFile.cpp
+++ b/CStackFile.cpp
@@ -16,7 +16,7 @@
 #include "woba.h"
 #include "CBuf.h"
 #include "EndianStuff.h"
-#include "snd2wav.h"
+#include "snd2wav/snd2wav/snd2wav.h"
 
 #if !MAC_CODE
 #include <unistd.h>

--- a/CStackFile.cpp
+++ b/CStackFile.cpp
@@ -18,6 +18,10 @@
 #include "EndianStuff.h"
 #include "snd2wav.h"
 
+#if !MAC_CODE
+#include <unistd.h>
+#endif
+
 
 // Table of C-strings for converting the non-ASCII MacRoman characters (above 127)
 //	into the requisite UTF8 byte sequences:

--- a/CStackFile.h
+++ b/CStackFile.h
@@ -26,6 +26,8 @@
 #if USE_QUICKTIME
 #include <QuickTime/QuickTime.h>
 #endif
+#else
+#include <cstring>
 #endif
 
 

--- a/EndianStuff.h
+++ b/EndianStuff.h
@@ -9,7 +9,9 @@
 
 #pragma once
 
+#if MAC_CODE
 #include <Carbon/Carbon.h>	// For Endian.h
+#endif
 #include <stdint.h>
 
 #if TARGET_RT_BIG_ENDIAN

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ functionality, you'll also have to write code to replace the Mac-specific code (
 resource fork of the stack and converts 'snd ' resources to AIFF -- the resource-fork-reading code in
 https://github.com/uliwitness/reclassicfication may be a good starting point).
 
+For example, on GNU/Linux-based systems such as Debian, the following has been known to work:
+
+    g++ -o stackimport woba.cpp Tests.cpp picture.cpp main.cpp CStackFile.cpp CBuf.cpp byteutils.cpp -std=gnu++11
+
 
 How to use this
 ---------------

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,8 @@
 #include <iostream>
+#if !MAC_CODE
+#include <linux/limits.h>
+#include <unistd.h>
+#endif
 #include "CStackFile.h"
 
 


### PR DESCRIPTION
Two commits which allow stackimport to be compiled on GNU/Linux.
The first adds some additional includes and wraps them in '#if MAC_CODE'
blocks to ensure that Mac compilation works as well. The second commit
alters the path to the 'snd2wav.h' file so that it points to the actual file
in the directory structure.(This is necessary on GNU/Linux systems, however
if it breaks anything on theMac side it can be removed).An additional commit
updates the readme file.

This has been tested on Debian 8.7 64-bit (Intel i5). No other platforms have
been tested, nor has Mac compilation with these changes. Please also note that
my knowledge of C++ is virtually zero, in most cases I just looked up the error
messages to resolve compilation issues. Please bear this in mind before
accepting this PR!